### PR TITLE
Add support for slashes in symbols

### DIFF
--- a/src/Edhen/Tokenizer.php
+++ b/src/Edhen/Tokenizer.php
@@ -206,6 +206,7 @@ class Tokenizer
             case 'nil':
                 return new Token(Token::NIL);
             default:
+                $this->validateSymbol($value);
                 return new Token(Token::SYMBOL, $value);
         }
     }
@@ -235,7 +236,7 @@ class Tokenizer
      */
     protected function isSymbolStart($c)
     {
-        return preg_match('/^[<>0-9a-z.*+!\-_?$%&=]+$/i', $c);
+        return preg_match('/^[<>0-9a-z.*+!\-_?$%&=\/]+$/i', $c);
     }
 
     /**
@@ -318,5 +319,25 @@ class Tokenizer
                     )
                 );
         }
+    }
+
+    private function validateSymbol($value)
+    {
+        // Validate it contains up to one forward slash, and that either it is either a single
+        // slash character or it separates a prefix and name parts. See https://github.com/edn-format/edn#symbols
+
+        $slashPosition = strpos($value, "/");
+        if ($slashPosition !== false) {
+            if (strlen($value) > 1) {
+                if ($slashPosition == 0) {
+                    throw new TokenizerException("Invalid symbol '$value': Symbols cannot start with a slash");
+                }
+                if ($slashPosition == strlen($value) - 1) {
+                    throw new TokenizerException("Invalid symbol '$value': Symbols cannot end with a slash");
+                }
+            }
+        }
+
+
     }
 }

--- a/src/Edhen/Tokenizer.php
+++ b/src/Edhen/Tokenizer.php
@@ -326,6 +326,10 @@ class Tokenizer
         // Validate it contains up to one forward slash, and that either it is either a single
         // slash character or it separates a prefix and name parts. See https://github.com/edn-format/edn#symbols
 
+        if (substr_count($value, "/") > 1) {
+            throw new TokenizerException("Invalid symbol '$value': Symbols can only contain zero or one slashes");
+        }
+
         $slashPosition = strpos($value, "/");
         if ($slashPosition !== false) {
             if (strlen($value) > 1) {
@@ -336,6 +340,7 @@ class Tokenizer
                     throw new TokenizerException("Invalid symbol '$value': Symbols cannot end with a slash");
                 }
             }
+
         }
 
 

--- a/src/Edhen/Tokenizer.php
+++ b/src/Edhen/Tokenizer.php
@@ -206,7 +206,6 @@ class Tokenizer
             case 'nil':
                 return new Token(Token::NIL);
             default:
-                $this->validateSymbol($value);
                 return new Token(Token::SYMBOL, $value);
         }
     }
@@ -319,30 +318,5 @@ class Tokenizer
                     )
                 );
         }
-    }
-
-    private function validateSymbol($value)
-    {
-        // Validate it contains up to one forward slash, and that either it is either a single
-        // slash character or it separates a prefix and name parts. See https://github.com/edn-format/edn#symbols
-
-        if (substr_count($value, "/") > 1) {
-            throw new TokenizerException("Invalid symbol '$value': Symbols can only contain zero or one slashes");
-        }
-
-        $slashPosition = strpos($value, "/");
-        if ($slashPosition !== false) {
-            if (strlen($value) > 1) {
-                if ($slashPosition == 0) {
-                    throw new TokenizerException("Invalid symbol '$value': Symbols cannot start with a slash");
-                }
-                if ($slashPosition == strlen($value) - 1) {
-                    throw new TokenizerException("Invalid symbol '$value': Symbols cannot end with a slash");
-                }
-            }
-
-        }
-
-
     }
 }

--- a/tests/Edhen/TokenizerTest.php
+++ b/tests/Edhen/TokenizerTest.php
@@ -2,6 +2,7 @@
 
 namespace Edhen;
 
+use Edhen\Exception\TokenizerException;
 use Edhen\Token;
 
 class TokenizerTest extends \PHPUnit_Framework_TestCase
@@ -233,5 +234,49 @@ class TokenizerTest extends \PHPUnit_Framework_TestCase
                 new Token(Token::SYMBOL, 'baz')
             )
         );
+    }
+
+    public function testValidSymbolsWithSlashesCanBeRead()
+    {
+        $this->assertTokens(
+            "/",
+            array(
+                new Token(Token::SYMBOL, '/')
+            )
+        );
+
+        $this->assertTokens(
+            "namespace/symbol",
+            array(
+                new Token(Token::SYMBOL, 'namespace/symbol')
+            )
+        );
+    }
+
+    public function testInvalidSymbolsWithSlashesCannotBeRead()
+    {
+        try {
+            $thrown = false;
+            $tokenizer = new Tokenizer("/name");
+            $tokenizer->nextToken();
+        } catch (TokenizerException $e) {
+            $thrown = true;
+        } finally {
+            if (!$thrown) {
+                $this->fail("Failed to throw during tokenization of invalid symbol (starting with slash)");
+            }
+        }
+
+        try {
+            $thrown = false;
+            $tokenizer = new Tokenizer("namespace/");
+            $tokenizer->nextToken();
+        } catch (TokenizerException $e) {
+            $thrown = true;
+        } finally {
+            if (!$thrown) {
+                $this->fail("Failed to throw during tokenization of invalid symbol (end with slash)");
+            }
+        }
     }
 }

--- a/tests/Edhen/TokenizerTest.php
+++ b/tests/Edhen/TokenizerTest.php
@@ -236,7 +236,7 @@ class TokenizerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testValidSymbolsWithSlashesCanBeRead()
+    public function testValidSymbolsWithASlashCanBeRead()
     {
         $this->assertTokens(
             "/",
@@ -253,7 +253,7 @@ class TokenizerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testInvalidSymbolsWithSlashesCannotBeRead()
+    public function testInvalidSymbolsWithASlashCannotBeRead()
     {
         try {
             $thrown = false;
@@ -276,6 +276,33 @@ class TokenizerTest extends \PHPUnit_Framework_TestCase
         } finally {
             if (!$thrown) {
                 $this->fail("Failed to throw during tokenization of invalid symbol (end with slash)");
+            }
+        }
+    }
+
+    public function testSymbolsWithMultipleSlashesCannotBeRead()
+    {
+        try {
+            $thrown = false;
+            $tokenizer = new Tokenizer("namespace//name");
+            $tokenizer->nextToken();
+        } catch (TokenizerException $e) {
+            $thrown = true;
+        } finally {
+            if (!$thrown) {
+                $this->fail("Failed to throw during tokenization of invalid symbol (with more than one slash)");
+            }
+        }
+
+        try {
+            $thrown = false;
+            $tokenizer = new Tokenizer("//");
+            $tokenizer->nextToken();
+        } catch (TokenizerException $e) {
+            $thrown = true;
+        } finally {
+            if (!$thrown) {
+                $this->fail("Failed to throw during tokenization of invalid symbol (with more than one slash)");
             }
         }
     }


### PR DESCRIPTION
As per the spec:

> `/` has special meaning in symbols. It can be used once only in the middle of a symbol to separate
the _prefix_ (often a namespace) from the _name_, e.g. `my-namespace/foo`. `/` by itself is a legal
symbol, but otherwise neither the _prefix_ nor the _name_ part can be empty when the symbol
contains `/`

I've added support for this bit by just allowing slashes to be starting characters and then validating that there are zero or one slashes, and if there is one, that is not at the beginning or end of the symbol if the symbol is longer than one character.

I thought that given that the rule is not trivial it was better to add it as an after-the-fact check to be run once per symbol instead of making the tokenizer code dirty with additional checks.
